### PR TITLE
i2b2 image modified to reflect modifications in the loader

### DIFF
--- a/docker-images/i2b2/sql/00-i2b2-schemas.sh
+++ b/docker-images/i2b2/sql/00-i2b2-schemas.sh
@@ -13,7 +13,8 @@ EOSQL
 }
 
 # init demo i2b2 database
-initSchema $I2B2_DB_NAME i2b2demodata_i2b2
+initSchema $I2B2_DB_NAME i2b2demodata_i2b2_non_sensitive
+initSchema $I2B2_DB_NAME i2b2demodata_i2b2_sensitive
 initSchema $I2B2_DB_NAME i2b2imdata
 initSchema $I2B2_DB_NAME i2b2metadata_i2b2
 initSchema $I2B2_DB_NAME i2b2workdata

--- a/docker-images/i2b2/sql/50-medco-schemas.sh
+++ b/docker-images/i2b2/sql/50-medco-schemas.sh
@@ -13,4 +13,5 @@ EOSQL
 }
 
 # init demo i2b2 database
-initSchema $I2B2_DB_NAME medco_ont
+initSchema $I2B2_DB_NAME medco_ont_sensitive
+initSchema $I2B2_DB_NAME medco_ont_non_sensitive

--- a/docker-images/i2b2/sql/65-medco-ontology.sh
+++ b/docker-images/i2b2/sql/65-medco-ontology.sh
@@ -5,7 +5,7 @@ set -Eeuo pipefail
 psql $PSQL_PARAMS -d "$I2B2_DB_NAME" <<-EOSQL
 
     -- table_access
-    CREATE TABLE medco_ont.table_access(
+    CREATE TABLE medco_ont_sensitive.table_access(
         C_TABLE_CD VARCHAR(50) PRIMARY KEY,
         C_TABLE_NAME VARCHAR(50),
         C_PROTECTED_ACCESS CHAR(1),
@@ -30,31 +30,59 @@ psql $PSQL_PARAMS -d "$I2B2_DB_NAME" <<-EOSQL
         C_STATUS_CD CHAR(1),
         VALUETYPE_CD VARCHAR(50)
     );
-    ALTER TABLE medco_ont.table_access OWNER TO $I2B2_DB_USER;
+    ALTER TABLE medco_ont_sensitive.table_access OWNER TO $I2B2_DB_USER;
 
-    insert into medco_ont.table_access (c_table_cd, c_table_name, c_protected_access, c_hlevel, c_fullname, c_name,
+    -- table_access
+    CREATE TABLE medco_ont_non_sensitive.table_access(
+        C_TABLE_CD VARCHAR(50) PRIMARY KEY,
+        C_TABLE_NAME VARCHAR(50),
+        C_PROTECTED_ACCESS CHAR(1),
+        C_HLEVEL NUMERIC(22,0),
+        C_FULLNAME VARCHAR(900),
+        C_NAME VARCHAR(2000),
+        C_SYNONYM_CD CHAR(1),
+        C_VISUALATTRIBUTES CHAR(3),
+        C_TOTALNUM NUMERIC(22,0),
+        C_BASECODE VARCHAR(450),
+        C_METADATAXML TEXT,
+        C_FACTTABLECOLUMN VARCHAR(50),
+        C_DIMTABLENAME VARCHAR(50),
+        C_COLUMNNAME VARCHAR(50),
+        C_COLUMNDATATYPE VARCHAR(50),
+        C_OPERATOR VARCHAR(10),
+        C_DIMCODE VARCHAR(900),
+        C_COMMENT TEXT,
+        C_TOOLTIP VARCHAR(900),
+        C_ENTRY_DATE DATE,
+        C_CHANGE_DATE DATE,
+        C_STATUS_CD CHAR(1),
+        VALUETYPE_CD VARCHAR(50)
+    );
+    ALTER TABLE medco_ont_non_sensitive.table_access OWNER TO $I2B2_DB_USER;
+
+    insert into medco_ont_sensitive.table_access (c_table_cd, c_table_name, c_protected_access, c_hlevel, c_fullname, c_name,
         c_synonym_cd, c_visualattributes, c_facttablecolumn, c_dimtablename,
         c_columnname, c_columndatatype, c_operator, c_dimcode, c_tooltip) VALUES
         ('SENSITIVE_TAGGED', 'SENSITIVE_TAGGED', 'N', 1, '\medco\tagged\', 'MedCo Sensitive Tagged Ontology',
         'N', 'CH', 'concept_cd', 'concept_dimension', 'concept_path', 'T', 'LIKE', '\medco\tagged\', 'MedCo Sensitive Tagged Ontology');
 
     -- schemes
-    CREATE TABLE medco_ont.schemes(
+    CREATE TABLE medco_ont_sensitive.schemes(
         C_KEY VARCHAR(50) NOT NULL,
         C_NAME VARCHAR(50) NOT NULL,
         C_DESCRIPTION VARCHAR(100),
         CONSTRAINT SCHEMES_PK PRIMARY KEY (C_KEY)
     );
-    ALTER TABLE medco_ont.schemes OWNER TO $I2B2_DB_USER;
+    ALTER TABLE medco_ont_sensitive.schemes OWNER TO $I2B2_DB_USER;
 
     -- todo: revise those schemes
-    insert into medco_ont.schemes(c_key, c_name, c_description) values('TAG_ID:', 'TAG_ID', 'MedCo tag identifier');
-    insert into medco_ont.schemes(c_key, c_name, c_description) values('ENC_ID:', 'ENC_ID', 'MedCo sensitive concept identifier (to be encrypted)');
-    insert into medco_ont.schemes(c_key, c_name, c_description) values('CLEAR:', 'CLEAR', 'MedCo clear value');
-    insert into medco_ont.schemes(c_key, c_name, c_description) values('GEN:', 'GEN', 'MedCo genomic annotations');
+    insert into medco_ont_sensitive.schemes(c_key, c_name, c_description) values('TAG_ID:', 'TAG_ID', 'MedCo tag identifier');
+    insert into medco_ont_sensitive.schemes(c_key, c_name, c_description) values('ENC_ID:', 'ENC_ID', 'MedCo sensitive concept identifier (to be encrypted)');
+    insert into medco_ont_sensitive.schemes(c_key, c_name, c_description) values('CLEAR:', 'CLEAR', 'MedCo clear value');
+    insert into medco_ont_sensitive.schemes(c_key, c_name, c_description) values('GEN:', 'GEN', 'MedCo genomic annotations');
 
     -- tagged sensitive ontology
-    CREATE TABLE medco_ont.sensitive_tagged (
+    CREATE TABLE medco_ont_sensitive.sensitive_tagged (
         c_hlevel numeric(22,0) not null,
         c_fullname character varying(900) not null,
         c_name character varying(2000) not null,
@@ -82,16 +110,21 @@ psql $PSQL_PARAMS -d "$I2B2_DB_NAME" <<-EOSQL
         c_symbol character varying(50),
         pcori_basecode character varying(50)
     );
-    ALTER TABLE medco_ont.sensitive_tagged OWNER TO $I2B2_DB_USER;
-    CREATE INDEX META_FULLNAME_IDX_sensitive_tagged ON medco_ont.sensitive_tagged(C_FULLNAME);
-    CREATE INDEX META_APPLIED_PATH_IDX_sensitive_tagged ON medco_ont.sensitive_tagged(M_APPLIED_PATH);
-    CREATE INDEX META_EXCLUSION_IDX_sensitive_tagged ON medco_ont.sensitive_tagged(M_EXCLUSION_CD);
-    CREATE INDEX META_HLEVEL_IDX_sensitive_tagged ON medco_ont.sensitive_tagged(C_HLEVEL);
-    CREATE INDEX META_SYNONYM_IDX_sensitive_tagged ON medco_ont.sensitive_tagged(C_SYNONYM_CD);
+    ALTER TABLE medco_ont_sensitive.sensitive_tagged OWNER TO $I2B2_DB_USER;
+    CREATE INDEX META_FULLNAME_IDX_sensitive_tagged ON medco_ont_sensitive.sensitive_tagged(C_FULLNAME);
+    CREATE INDEX META_APPLIED_PATH_IDX_sensitive_tagged ON medco_ont_sensitive.sensitive_tagged(M_APPLIED_PATH);
+    CREATE INDEX META_EXCLUSION_IDX_sensitive_tagged ON medco_ont_sensitive.sensitive_tagged(M_EXCLUSION_CD);
+    CREATE INDEX META_HLEVEL_IDX_sensitive_tagged ON medco_ont_sensitive.sensitive_tagged(C_HLEVEL);
+    CREATE INDEX META_SYNONYM_IDX_sensitive_tagged ON medco_ont_sensitive.sensitive_tagged(C_SYNONYM_CD);
 
     -- permissions
-    grant all on schema medco_ont to $I2B2_DB_USER;
-    grant all privileges on all tables in schema medco_ont to $I2B2_DB_USER;
-    grant all privileges on all sequences in schema medco_ont to $I2B2_DB_USER;
-    grant all privileges on all functions in schema medco_ont to $I2B2_DB_USER;
+    grant all on schema medco_ont_sensitive to $I2B2_DB_USER;
+    grant all privileges on all tables in schema medco_ont_sensitive to $I2B2_DB_USER;
+    grant all privileges on all sequences in schema medco_ont_sensitive to $I2B2_DB_USER;
+    grant all privileges on all functions in schema medco_ont_sensitive to $I2B2_DB_USER;
+
+    grant all on schema medco_ont_non_sensitive to $I2B2_DB_USER;
+    grant all privileges on all tables in schema medco_ont_non_sensitive to $I2B2_DB_USER;
+    grant all privileges on all sequences in schema medco_ont_non_sensitive to $I2B2_DB_USER;
+    grant all privileges on all functions in schema medco_ont_non_sensitive to $I2B2_DB_USER;
 EOSQL

--- a/docker-images/i2b2/sql/70-i2b2-modifications.sh
+++ b/docker-images/i2b2/sql/70-i2b2-modifications.sh
@@ -5,9 +5,9 @@ set -Eeuo pipefail
 psql $PSQL_PARAMS -d "$I2B2_DB_NAME" <<-EOSQL
 
     -- add encrypted dummy flags for patient_dimension in crc schema
-    ALTER TABLE i2b2demodata_i2b2.patient_dimension ADD COLUMN enc_dummy_flag_cd character(88);
-    COMMENT ON COLUMN i2b2demodata_i2b2.patient_dimension.enc_dummy_flag_cd IS 'base64-encoded encrypted dummy flag (0 or 1)';
-    INSERT INTO i2b2demodata_i2b2.code_lookup VALUES
+    ALTER TABLE i2b2demodata_i2b2_sensitive.patient_dimension ADD COLUMN enc_dummy_flag_cd character(88);
+    COMMENT ON COLUMN i2b2demodata_i2b2_sensitive.patient_dimension.enc_dummy_flag_cd IS 'base64-encoded encrypted dummy flag (0 or 1)';
+    INSERT INTO i2b2demodata_i2b2_sensitive.code_lookup VALUES
         ('patient_dimension', 'enc_dummy_flag_cd', 'CRC_COLUMN_DESCRIPTOR', 'Encrypted Dummy Flag', NULL, NULL, NULL,
         NULL, 'NOW()', NULL, 1);
 

--- a/resources/data/download.sh
+++ b/resources/data/download.sh
@@ -30,5 +30,6 @@ wget -O ${SCRIPT_FOLDER}/i2b2/original/patient_dimension.csv ${REPO_URL}/i2b2/or
 wget -O ${SCRIPT_FOLDER}/i2b2/original/table_access.csv ${REPO_URL}/i2b2/original/table_access.csv?raw=true
 wget -O ${SCRIPT_FOLDER}/i2b2/original/visit_dimension.csv ${REPO_URL}/i2b2/original/visit_dimension.csv?raw=true
 wget -O ${SCRIPT_FOLDER}/i2b2/original/concept_dimension.csv ${REPO_URL}/i2b2/original/concept_dimension.csv?raw=true
+wget -O ${SCRIPT_FOLDER}/i2b2/original/modifier_dimension.csv ${REPO_URL}/i2b2/original/modifier_dimension.csv?raw=true
 wget -O ${SCRIPT_FOLDER}/i2b2/sensitive.txt ${REPO_URL}/i2b2/sensitive.txt?raw=true
 wget -O ${SCRIPT_FOLDER}/i2b2/files.toml ${REPO_URL}/i2b2/files.toml?raw=true


### PR DESCRIPTION
@mickmis I tried to modify the i2b2 image to reflect the changes we made in the loader. I am not sure if what I did is correct though, so here is a pull request to check with you. The only modification we made in the loader the affect the deployment is that we split  the i2b2demodata_i2b2 and medco_ont schemes in two schemes each, one for the sensitive and one for the non sensitive data. I found the sql scripts referencing those schemas in the repository and tried to modify them in a way that seemed reasonable, but please have a look (not sure what to do with the functions in 85-data-manipulation-functions).