### PR TITLE
changed genomic annotation user and database to medco connector

### DIFF
--- a/compose-profiles/dev-local-3nodes/docker-compose.tools.yml
+++ b/compose-profiles/dev-local-3nodes/docker-compose.tools.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - LOG_LEVEL=5
       - I2B2_DB_NAME=i2b2medcosrv0
-      - GA_DB_NAME=gamedcosrv0
+      - MC_DB_NAME=medcoconnectorsrv0
       - UNLYNX_GROUP_FILE_IDX=0
 
   medco-loader-srv1:
@@ -24,7 +24,7 @@ services:
     environment:
       - LOG_LEVEL=5
       - I2B2_DB_NAME=i2b2medcosrv1
-      - GA_DB_NAME=gamedcosrv1
+      - MC_DB_NAME=medcoconnectorsrv1
       - UNLYNX_GROUP_FILE_IDX=1
 
   medco-loader-srv2:
@@ -34,5 +34,5 @@ services:
     environment:
       - LOG_LEVEL=5
       - I2B2_DB_NAME=i2b2medcosrv2
-      - GA_DB_NAME=gamedcosrv2
+      - MC_DB_NAME=medcoconnectorsrv2
       - UNLYNX_GROUP_FILE_IDX=2

--- a/compose-profiles/dev-local-3nodes/docker-compose.yml
+++ b/compose-profiles/dev-local-3nodes/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - I2B2_LOGIN_PASSWORD=e2etest
       - LOG_LEVEL=5
       - MEDCO_NODE_IDX=0
-      - GA_DB_NAME=gamedcosrv0
+      - MC_DB_NAME=medcoconnectorsrv0
       - OIDC_JWKS_URLS=http://keycloak:8080/auth/realms/master/protocol/openid-connect/certs,https://medco-demo.epfl.ch/auth/realms/master/protocol/openid-connect/certs
       - OIDC_JWT_ISSUERS=http://localhost/auth/realms/master,https://medco-demo.epfl.ch/auth/realms/master
       - OIDC_CLIENT_IDS=medco,medco
@@ -100,7 +100,7 @@ services:
       - I2B2_LOGIN_PASSWORD=e2etest
       - LOG_LEVEL=5
       - MEDCO_NODE_IDX=1
-      - GA_DB_NAME=gamedcosrv1
+      - MC_DB_NAME=medcoconnectorsrv1
       - OIDC_JWKS_URLS=http://keycloak:8080/auth/realms/master/protocol/openid-connect/certs,https://medco-demo.epfl.ch/auth/realms/master/protocol/openid-connect/certs
       - OIDC_JWT_ISSUERS=http://localhost/auth/realms/master,https://medco-demo.epfl.ch/auth/realms/master
       - OIDC_CLIENT_IDS=medco,medco
@@ -155,7 +155,7 @@ services:
       - I2B2_LOGIN_PASSWORD=e2etest
       - LOG_LEVEL=5
       - MEDCO_NODE_IDX=2
-      - GA_DB_NAME=gamedcosrv2
+      - MC_DB_NAME=medcoconnectorsrv2
       - OIDC_JWKS_URLS=http://keycloak:8080/auth/realms/master/protocol/openid-connect/certs,https://medco-demo.epfl.ch/auth/realms/master/protocol/openid-connect/certs
       - OIDC_JWT_ISSUERS=http://localhost/auth/realms/master,https://medco-demo.epfl.ch/auth/realms/master
       - OIDC_CLIENT_IDS=medco,medco

--- a/compose-profiles/docker-compose-definitions.yml
+++ b/compose-profiles/docker-compose-definitions.yml
@@ -96,11 +96,11 @@ services:
       - MEDCO_OBFUSCATION_MIN=5
       - MEDCO_NODES_URL=http://localhost/local-3nodes/medco-0,http://localhost/local-3nodes/medco-1,http://localhost/local-3nodes/medco-2
       - MEDCO_NODE_IDX=0
-      - GA_DB_HOST=postgresql
-      - GA_DB_PORT=5432
-      - GA_DB_USER=genomicannotations
-      - GA_DB_PW=genomicannotations
-      - GA_DB_NAME=gamedco
+      - MC_DB_HOST=postgresql
+      - MC_DB_PORT=5432
+      - MC_DB_USER=medcoconnector
+      - MC_DB_PW=medcoconnector
+      - MC_DB_NAME=medcoconnector
     volumes:
       - ../configuration-profiles/dev-local-3nodes:/medco-configuration
 
@@ -131,11 +131,11 @@ services:
       - I2B2_DB_NAME=i2b2medco
       - I2B2_DB_USER=i2b2
       - I2B2_DB_PASSWORD=i2b2
-      - GA_DB_HOST=localhost
-      - GA_DB_PORT=5432
-      - GA_DB_NAME=gamedco
-      - GA_DB_USER=genomicannotations
-      - GA_DB_PASSWORD=genomicannotations
+      - MC_DB_HOST=localhost
+      - MC_DB_PORT=5432
+      - MC_DB_NAME=medcoconnector
+      - MC_DB_USER=medcoconnector
+      - MC_DB_PASSWORD=medcoconnector
     volumes:
       - ../resources/data:/data
       - ../configuration-profiles/dev-local-3nodes:/medco-configuration

--- a/compose-profiles/test-local-3nodes/docker-compose.tools.yml
+++ b/compose-profiles/test-local-3nodes/docker-compose.tools.yml
@@ -16,10 +16,10 @@ services:
       service: medco-loader
     environment:
       - I2B2_DB_NAME=i2b2medcosrv0
-      - GA_DB_NAME=gamedcosrv0
+      - MC_DB_NAME=medcoconnectorsrv0
       - UNLYNX_GROUP_FILE_IDX=0
       - I2B2_DB_HOST=${MEDCO_NODE_HOST:?}
-      - GA_DB_HOST=${MEDCO_NODE_HOST:?}
+      - MC_DB_HOST=${MEDCO_NODE_HOST:?}
     volumes:
       - ../../configuration-profiles/test-local-3nodes:/medco-configuration
 
@@ -29,10 +29,10 @@ services:
       service: medco-loader
     environment:
       - I2B2_DB_NAME=i2b2medcosrv1
-      - GA_DB_NAME=gamedcosrv1
+      - MC_DB_NAME=medcoconnectorsrv1
       - UNLYNX_GROUP_FILE_IDX=1
       - I2B2_DB_HOST=${MEDCO_NODE_HOST:?}
-      - GA_DB_HOST=${MEDCO_NODE_HOST:?}
+      - MC_DB_HOST=${MEDCO_NODE_HOST:?}
     volumes:
       - ../../configuration-profiles/test-local-3nodes:/medco-configuration
 
@@ -42,9 +42,9 @@ services:
       service: medco-loader
     environment:
       - I2B2_DB_NAME=i2b2medcosrv2
-      - GA_DB_NAME=gamedcosrv0
+      - MC_DB_NAME=medcoconnectorsrv0
       - UNLYNX_GROUP_FILE_IDX=2
       - I2B2_DB_HOST=${MEDCO_NODE_HOST:?}
-      - GA_DB_HOST=${MEDCO_NODE_HOST:?}
+      - MC_DB_HOST=${MEDCO_NODE_HOST:?}
     volumes:
       - ../../configuration-profiles/test-local-3nodes:/medco-configuration

--- a/compose-profiles/test-local-3nodes/docker-compose.yml
+++ b/compose-profiles/test-local-3nodes/docker-compose.yml
@@ -46,7 +46,7 @@ services:
       - MEDCO_NODE_IDX=0
       - OIDC_JWT_ISSUERS=${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/auth/realms/master
       - I2B2_LOGIN_PASSWORD=${I2B2_USER_PASSWORD:?}
-      - GA_DB_NAME=gamedcosrv0
+      - MC_DB_NAME=medcoconnectorsrv0
       - "MEDCO_NODES_URL=\
       ${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/local-3nodes/medco-0,\
       ${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/local-3nodes/medco-1,\
@@ -103,7 +103,7 @@ services:
       - MEDCO_NODE_IDX=1
       - OIDC_JWT_ISSUERS=${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/auth/realms/master
       - I2B2_LOGIN_PASSWORD=${I2B2_USER_PASSWORD:?}
-      - GA_DB_NAME=gamedcosrv1
+      - MC_DB_NAME=medcoconnectorsrv1
       - "MEDCO_NODES_URL=\
       ${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/local-3nodes/medco-0,\
       ${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/local-3nodes/medco-1,\
@@ -160,7 +160,7 @@ services:
       - MEDCO_NODE_IDX=2
       - OIDC_JWT_ISSUERS=${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/auth/realms/master
       - I2B2_LOGIN_PASSWORD=${I2B2_USER_PASSWORD:?}
-      - GA_DB_NAME=gamedcosrv2
+      - MC_DB_NAME=medcoconnectorsrv2
       - "MEDCO_NODES_URL=\
       ${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/local-3nodes/medco-0,\
       ${MEDCO_NODE_HTTP_SCHEME:?}://${MEDCO_NODE_HOST:?}/local-3nodes/medco-1,\

--- a/docker-images/postgresql/initdb-data/00-roles.sql
+++ b/docker-images/postgresql/initdb-data/00-roles.sql
@@ -1,6 +1,6 @@
 CREATE ROLE i2b2 LOGIN PASSWORD 'i2b2';
 CREATE ROLE keycloak LOGIN PASSWORD 'keycloak';
-CREATE ROLE genomicannotations LOGIN PASSWORD 'genomicannotations';
+CREATE ROLE medcoconnector LOGIN PASSWORD 'medcoconnector';
 ALTER USER i2b2 CREATEDB;
 ALTER USER keycloak CREATEDB;
-ALTER USER genomicannotations CREATEDB;
+ALTER USER medcoconnector CREATEDB;

--- a/resources/profile-generation-scripts/test-network/docker-compose.tools.yml
+++ b/resources/profile-generation-scripts/test-network/docker-compose.tools.yml
@@ -19,6 +19,6 @@ services:
     environment:
       - UNLYNX_GROUP_FILE_IDX=${MEDCO_NODE_IDX:?}
       - I2B2_DB_HOST=${MEDCO_NODE_DNS_NAME:?}
-      - GA_DB_HOST=${MEDCO_NODE_DNS_NAME:?}
+      - MC_DB_HOST=${MEDCO_NODE_DNS_NAME:?}
     volumes:
       - ../../configuration-profiles/${MEDCO_PROFILE_NAME:?}:/medco-configuration


### PR DESCRIPTION
As new schemata will be added to the medco connector database, genomicannotation postgres user and gamedcosrv database are renamed respectively medcoconnector and medcoconnectorsrv respectively.

These names more generic and show the direct link between this DB and the medco connector.